### PR TITLE
Post index restyle

### DIFF
--- a/assets/css/base/_animations.scss
+++ b/assets/css/base/_animations.scss
@@ -52,13 +52,6 @@
     }
 }
 
-@keyframes postTagSlideIn {
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
-}
-
 @keyframes randomBtnSlideInFromLeft {
     from {
         opacity: 0;

--- a/assets/css/base/_animations.scss
+++ b/assets/css/base/_animations.scss
@@ -52,16 +52,6 @@
     }
 }
 
-@keyframes postLinkAnim {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-        transform: translate(0);
-    }
-}
-
 @keyframes postTagSlideIn {
     to {
         opacity: 1;

--- a/assets/css/base/_constants.scss
+++ b/assets/css/base/_constants.scss
@@ -80,6 +80,7 @@ $font-size-base: 1.07rem;
 $font-size-xs: 0.8rem;
 $font-size-sm: 0.9rem;
 $font-size-md: 1rem;
+$font-size-lg: 1.1rem;
 $font-size-h1: clamp(1rem, 7vw, 3rem);
 $font-size-h2: 1.6rem;
 $font-size-h3: 1.4rem;

--- a/assets/css/base/_constants.scss
+++ b/assets/css/base/_constants.scss
@@ -28,7 +28,8 @@ $color-article: rgb(30, 30, 30);
 $color-panel: rgb(31, 31, 31);
 $color-panel-zebra: darken($color-panel, 1%);
 $color-panel-dark: darken($color-panel, 3%);
-$color-panel-hover: transparentize(lighten($color-panel, 7%), 0.5);
+$color-panel-hover: lighten($color-panel, 4%);
+$color-panel-hover-subtle: lighten($color-panel, 1%);
 
 $color-card: rgba(40, 40, 40, 0.8);
 $color-card-hover: rgba(50, 50, 50, 0.9);
@@ -76,6 +77,7 @@ $font-weight-bold: 600;
 $font-weight-code: 400;
 
 $font-size-base: 1.07rem;
+$font-size-xs: 0.8rem;
 $font-size-sm: 0.9rem;
 $font-size-md: 1rem;
 $font-size-h1: clamp(1rem, 7vw, 3rem);

--- a/assets/css/components/_post-link.scss
+++ b/assets/css/components/_post-link.scss
@@ -69,9 +69,8 @@
     .tag {
         background: $color-accent-transparent-10;
         color: $color-accent;
-        font-family: $font-primary;
+        font-family: $font-secondary;
         font-size: $font-size-xs;
-        font-weight: $font-weight-bold;
         border-radius: $radius-round;
         padding: 0.2em 0.8em;
         border: $border-accent-t;

--- a/assets/css/components/_post-link.scss
+++ b/assets/css/components/_post-link.scss
@@ -1,16 +1,21 @@
 @import 'base/mixins';
 
+.post-links {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-sm;
+}
+
 .post-link {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1rem 1.5rem;
+    flex-direction: column;
+    gap: $spacing-xs;
+    padding: $spacing-md $spacing-lg;
     background: $color-panel;
-    border-radius: 12px;
+    border-radius: $radius-lg;
     box-shadow: $shadow-standard;
     border: $border-standard;
     text-decoration: none;
-    color: $color-text;
     transition:
         background 0.3s ease,
         border-color 0.3s ease,
@@ -19,97 +24,72 @@
     width: 100%;
     box-sizing: border-box;
     overflow: hidden;
-    margin-bottom: 1rem;
     cursor: pointer;
 
-    &.animated {
-        animation: postLinkAnim 1s
-            calc(var(--child-animation-delay) * 2 + 0.05s)
-            $transition-timing both;
-
-        @include notMobile {
-            transform: translateY(-10px);
-        }
-
-        @include mobile {
-            &:nth-child(odd) {
-                transform: translateX(50px);
-            }
-
-            &:nth-child(even) {
-                transform: translateX(-50px);
-            }
-        }
-    }
-
-    &:hover,
-    &:focus {
-        text-decoration: none;
-        background: $color-panel-hover;
-        border-color: rgba(143, 223, 212, 0.3);
-        transform: translateY(-3px);
+    &:hover, &:focus {
+        background: $color-panel-hover-subtle;
+        border-color: $color-accent-transparent-30;
         box-shadow: $shadow-standard-hover;
 
-        & .title {
+        .title {
             color: $color-accent;
         }
     }
 
-    & .content {
+    @include motion {
+        &:hover, &:focus {
+            .info {
+                letter-spacing: 0.2px;
+            }
+
+            .tags {
+                column-gap: 0.5em;
+            }
+        }
+
+        &:hover {
+            transform: translateY(-2px);
+        }
+    }
+
+    .content {
         display: flex;
         flex-direction: column;
         flex: 1 1 auto;
         min-width: 0;
     }
 
-    & .tags {
+    .tags {
         display: flex;
+        flex-wrap: wrap;
         gap: 0.4em;
-        flex-shrink: 0;
-        margin-left: 1em;
-        list-style: none;
-        padding: 0;
-        margin: 0;
-
-        @include mobile {
-            display: none;
-        }
+        transition: column-gap 0.35s ease;
     }
 
-    & .tag {
-        background: rgba(143, 223, 212, 0.15);
+    .tag {
+        background: $color-accent-transparent-10;
         color: $color-accent;
         font-family: $font-primary;
-        font-size: 0.8rem;
-        font-weight: 600;
-        border-radius: 999px;
+        font-size: $font-size-xs;
+        font-weight: $font-weight-bold;
+        border-radius: $radius-round;
         padding: 0.2em 0.8em;
-        white-space: nowrap;
-        border: 1px solid rgba(143, 223, 212, 0.25);
-        letter-spacing: 0.01em;
-        user-select: none;
-        pointer-events: none;
+        border: $border-accent-t;
         transition:
             background 0.2s,
             color 0.2s;
     }
 
-    & .title {
-        font-family: $font-secondary;
-        font-size: 1.1rem;
-        font-weight: 700;
-        display: block;
+    .title {
         color: $color-text;
         margin: 0;
-        transition: color 0.3s ease;
+        transition: color 0.2s ease;
     }
 
-    & .info {
+    .info {
         font-family: $font-primary;
-        font-size: 0.9rem;
+        font-size: $font-size-sm;
         color: $color-text-secondary;
-        line-height: 1.4;
-        display: block;
-        margin: 0.25rem 0 0 0;
+        transition: letter-spacing 0.3s ease;
     }
 }

--- a/assets/css/components/_post-link.scss
+++ b/assets/css/components/_post-link.scss
@@ -11,7 +11,7 @@
     border: $border-standard;
     text-decoration: none;
     color: $color-text;
-    transition: 
+    transition:
         background 0.3s ease,
         border-color 0.3s ease,
         transform 0.3s ease,
@@ -104,7 +104,7 @@
         transition: color 0.3s ease;
     }
 
-    & .description {
+    & .info {
         font-family: $font-primary;
         font-size: 0.9rem;
         color: $color-text-secondary;

--- a/assets/css/components/_post-tags.scss
+++ b/assets/css/components/_post-tags.scss
@@ -1,31 +1,32 @@
 .post-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5em;
+    gap: $spacing-xs;
     justify-content: center;
     align-items: center;
     margin: $spacing-md $spacing-xs $spacing-lg;
 
-    & .post-tag {
-        display: inline-block;
+    .post-tag {
         background: $color-accent-transparent-10;
         color: $color-accent;
-        border: $border-accent;
+        border: $border-accent-t;
         border-radius: $radius-round;
         padding: 0.2em 0.8em;
-        font-size: 0.95em;
+        font-size: $font-size-lg;
         font-family: $font-secondary;
         text-decoration: none;
         transition:
             background 0.2s,
-            color 0.2s,
-            border 0.2s;
+            color 0.2s;
+
+        @include mobile {
+            font-size: $font-size-md;
+        }
 
         &:hover,
         &:focus {
             background: $color-accent;
             color: $color-text-inverse;
-            border-color: $color-accent-light;
             text-decoration: none;
         }
 
@@ -35,5 +36,12 @@
             animation: postTagSlideIn 0.6s var(--child-animation-delay)
                 cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
         }
+    }
+}
+
+@keyframes postTagSlideIn {
+    to {
+        opacity: 1;
+        transform: translateX(0);
     }
 }

--- a/assets/css/components/_random-post-btn.scss
+++ b/assets/css/components/_random-post-btn.scss
@@ -9,11 +9,11 @@
         opacity: 0;
     }
 
-    & .random-post-btn {
+    .random-post-btn {
         background: $color-accent-transparent-10;
         color: $color-accent;
         text-decoration: none;
-        border: $border-accent;
+        border: $border-accent-t;
         border-radius: $radius-round;
         padding: 0.5em 1.5em;
         font-size: 1.1rem;

--- a/layouts/partials/post-info.html
+++ b/layouts/partials/post-info.html
@@ -1,0 +1,10 @@
+<div class="info animated">
+    <time datetime="{{ .Date.Format "2006-01-02" }}">
+        {{ .Date.Format "January 2, 2006" }}
+    </time>
+    {{ $readTime := (partial "read-time.html" .) }}
+    {{- if gt $readTime 1 }}
+    <span class="separator"> · </span>
+    <span class="read-time">{{ $readTime }} min read</span>
+    {{- end }}
+</div>

--- a/layouts/partials/post-links.html
+++ b/layouts/partials/post-links.html
@@ -1,15 +1,9 @@
 <nav class="post-links">
-    {{ range (where . "Params.unlisted" "ne" true).ByDate.Reverse }} {{ $post :=
-    . }} {{ $minRead := math.Ceil (div (countwords $post.Content) 200.0) }}
+    {{ range (where . "Params.unlisted" "ne" true).ByDate.Reverse }}
     <a class="post-link" href="{{ .Permalink | relURL }}">
         <div class="content">
             <h3 class="title">{{ .Title }}</h3>
-            <p class="description">
-                <time datetime="{{ .Date.Format "2006-01-02" }}">
-                    {{ .Date.Format "January 2, 2006" }}
-                </time>
-                {{ if gt $minRead 1 }} · {{ $minRead }} min read{{ end }}
-            </p>
+            {{ partial "post-info.html" . }}
         </div>
         <ul class="tags">
             {{ range .Params.tags | sort }}

--- a/layouts/partials/post-links.html
+++ b/layouts/partials/post-links.html
@@ -1,15 +1,13 @@
 <nav class="post-links">
     {{ range (where . "Params.unlisted" "ne" true).ByDate.Reverse }}
     <a class="post-link" href="{{ .Permalink | relURL }}">
-        <div class="content">
-            <h3 class="title">{{ .Title }}</h3>
-            {{ partial "post-info.html" . }}
-        </div>
-        <ul class="tags">
+        <h3 class="title">{{ .Title }}</h3>
+        {{ partial "post-info.html" . }}
+        <div class="tags">
             {{ range .Params.tags | sort }}
-            <li class="tag">{{ . }}</li>
+            <span class="tag">{{ . }}</span>
             {{ end }}
-        </ul>
+        </div>
     </a>
     {{ end }}
 </nav>

--- a/layouts/partials/read-time.html
+++ b/layouts/partials/read-time.html
@@ -1,0 +1,4 @@
+{{ $wordCount := .WordCount }}
+{{ $readingSpeed := 200 }}
+{{ $minutes := div $wordCount $readingSpeed }}
+{{ return $minutes }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -7,15 +7,7 @@
 {{- $minRead := math.Ceil (div (countwords $page.Content) 200.0) -}}
 <div class="frontmatter">
 <h1 class="animated title">{{ .Title }}</h1>
-{{- with .Date }}
-<div class="info animated">
-    <time datetime="{{ .Format "2006-01-02" }}">{{ .Format "January 2, 2006" }}</time>
-    {{- if gt $minRead 1 }}
-    <span class="separator"> · </span>
-    <span class="read-time">{{ $minRead }} min read</span>
-    {{- end }}
-</div>
-{{ end }}
+{{ partial "post-info.html" . }}
 {{- with .Params.tags }}
 <div class="post-tags">
     {{- range . | sort }}


### PR DESCRIPTION
Restyle the post-link and post-tag components, resulting in a different and better appearance on the main posts index page, each individual post page, and each tag page.

<table>
<thead>
  <tr>
    <th>Old</th>
    <th>New</th>
  </tr>
</thead>
<body>
  <tr>
    <td>
      <img width="1920" height="938" alt="Screenshot 2025-09-29 at 17-53-33 Posts" src="https://github.com/user-attachments/assets/b4fecfc3-a8d0-49f7-bcea-b6c301b48b34" />
    </td>
    <td>
      <img width="1920" height="938" alt="Screenshot 2025-09-29 at 17-53-22 Posts" src="https://github.com/user-attachments/assets/cce9ba5c-6652-4f27-bbf8-2ac70ea40e3b" />
    </td>
  </tr>
</body>
</table>
